### PR TITLE
Extend the JSON Schema to include SR OS type validation

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -53,8 +53,8 @@
                         "vr-juniper_vmx",
                         "vr-vqfx",
                         "vr-juniper_vqfx",
-			"vr-vsrx",
-			"vr-juniper_vsrx",
+                        "vr-vsrx",
+                        "vr-juniper_vsrx",
                         "vr-xrv",
                         "vr-cisco_xrv",
                         "vr-xrv9k",
@@ -303,48 +303,96 @@
                     "$ref": "#/definitions/certificate-config"
                 }
             },
-            "if": {
-                "properties": {
-                    "kind": {
-                        "const": "srl"
+            "allOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "type of a node",
+                            "markdownDescription": "node [type](https://containerlab.dev/manual/nodes/#type)"
+                        }
                     }
-                }
-            },
-            "then": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "type of a node",
-                        "markdownDescription": "node [type](https://containerlab.dev/manual/nodes/#type)",
-                        "enum": [
-                            "ixrd1",
-                            "ixrd2",
-                            "ixrd3",
-                            "ixrd2l",
-                            "ixrd3l",
-                            "ixrd4",
-                            "ixrd5",
-                            "ixrd5t",
-                            "ixrh2",
-                            "ixrh3",
-                            "ixrh4",
-                            "ixr6",
-                            "ixr6e",
-                            "ixr10",
-                            "ixr10e"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "kind": {
+                                "const": "srl"
+                            }
+                        },
+                        "required": [
+                            "kind"
                         ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "ixrd1",
+                                    "ixrd2",
+                                    "ixrd3",
+                                    "ixrd2l",
+                                    "ixrd3l",
+                                    "ixrd4",
+                                    "ixrd5",
+                                    "ixrd5t",
+                                    "ixrh2",
+                                    "ixrh3",
+                                    "ixrh4",
+                                    "ixr6",
+                                    "ixr6e",
+                                    "ixr10",
+                                    "ixr10e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "kind": {
+                                "const": "vr-sros"
+                            }
+                        },
+                        "required": [
+                            "kind"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "anyOf": [
+                                    {
+                                        "enum": [
+                                            "sr-1",
+                                            "sr-1e",
+                                            "sr-1e-sec",
+                                            "sr-1s",
+                                            "sr-1s-macsec",
+                                            "sr-2s",
+                                            "sr-7s",
+                                            "sr-7s-fp4",
+                                            "sr-14s",
+                                            "sr-a4",
+                                            "ixr-e-small",
+                                            "ixr-e-big",
+                                            "ixr-ec",
+                                            "ixr-r6",
+                                            "ixr-s"
+                                        ]
+                                    },
+                                    {
+                                        "pattern": "cp:.+"
+                                    }
+                                ]
+                            }
+                        }
                     }
                 }
-            },
-            "else": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "type of a node",
-                        "markdownDescription": "node [type](https://containerlab.dev/manual/nodes/#type)"
-                    }
-                }
-            },
+            ],
             "additionalProperties": false
         },
         "link-config": {


### PR DESCRIPTION
Added all options from https://github.com/hellt/vrnetlab/tree/master/sros to the schema

Using `allOf` to ensure different schemas for srl & vr-sros. vr-sros includes a pattern fallback to `cp:xxxx` strings for custom types

<img width="187" alt="image" src="https://github.com/kellerza/containerlab/assets/6756881/2db1163e-0dd3-42ae-8b03-6d4463b0845e">

<img width="179" alt="image" src="https://github.com/kellerza/containerlab/assets/6756881/f7cac866-0754-4a90-8583-363a8840531f">
